### PR TITLE
Revert to local1.* from ftp.*

### DIFF
--- a/rsyslog.d/20-user.conf
+++ b/rsyslog.d/20-user.conf
@@ -1,4 +1,4 @@
-ftp.*  {
+local1.*  {
     /proc/self/fd/2
     stop
 }


### PR DESCRIPTION
Seems like both 19-ftp.conf and 20-user.conf were updated to ftp.* instead of retaining their individual identities.  This change doesn't touch 19-ftp.conf, but changes 20-user.conf back to local1.*.